### PR TITLE
Add robots.txt to prevent search engine indexing

### DIFF
--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /
+
+# This is a review/development version of the site
+# Search engine indexing is currently disabled


### PR DESCRIPTION
## Summary
Add robots.txt file to prevent search engines from indexing the review/staging version of the Boston CPM website.

## Changes
- **robots.txt**: Added to dist/ directory with full disallow directive
- **SEO Protection**: Prevents duplicate content issues with future live site
- **Professional Practice**: Standard approach for staging environments

## Content
```
User-agent: *
Disallow: /

# This is a review/development version of the site
# Search engine indexing is currently disabled
```

## Deployment
- File will be deployed to GitHub Pages root directory
- Can be easily updated when ready to launch live site

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>